### PR TITLE
Pin Paintarena baseline commissioner

### DIFF
--- a/src/coworld/examples/paintarena/compose.yaml
+++ b/src/coworld/examples/paintarena/compose.yaml
@@ -5,5 +5,5 @@ services:
     build:
       context: .
   commissioner:
-    image: ${COMMISSIONER_IMAGE:?Set COMMISSIONER_IMAGE to a pinned commissioner image URI}
+    image: ghcr.io/metta-ai/commissioners-baseline@sha256:d3d2617ab93a7c5845d71c1b179b96435475d8c0fa9dedd8294f2f7795ec68c6
     platform: linux/amd64


### PR DESCRIPTION
Pins the Paintarena commissioner Compose service to the public baseline commissioner digest.

Context: these commissioner images are public GHCR images, so a manifest could mechanically use a `:latest` tag. We should still pin digests in active tournament Coworld manifests: commissioner jobs use `imagePullPolicy: Always`, so `:latest` would let the same Coworld version change scheduling/ranking behavior between rounds. The digest pin keeps the cutover deterministic and makes rollback/debugging tied to a specific image.

Validation:
- `uv run --extra test pytest tests/test_coworld_bundle.py -q`
- local CoworldManifest schema validation.