### PR TITLE
Add partial Coworld manifest uploads

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -764,6 +764,22 @@ uv run coworld upload-coworld tmp/paintarena/coworld_manifest.json
 `certify` runs the manifest's certification fixture locally, then validates results and replay artifacts. `upload-coworld`
 certifies again before uploading the manifest and runnable images.
 
+To publish a small update from an already uploaded Coworld, use the hosted manifest as the base. Only new local image
+refs are uploaded; unchanged `img_...` entries stay as-is:
+
+```bash
+uv run coworld upload-coworld --from-coworld cow_... \
+  --version 0.1.1 \
+  --image commissioner=paintarena-commissioner:latest
+
+uv run coworld upload-coworld --from-coworld paintarena \
+  --version 0.1.2 \
+  --set game.owner=games@softmax.com
+```
+
+Use `--image role.id=IMAGE` or `--image role[index]=IMAGE` when a role has more than one runnable. `--set` accepts
+manifest paths such as `game.description` or `commissioner[0].description`; values are JSON-decoded when possible.
+
 Inspect uploaded Coworlds and images:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,13 @@ dependencies = [
   "referencing>=0.36.2",
   "requests>=2.32",
   "rich>=13.7.0",
-  "softmax-cli==0.26.18",
+  "softmax-cli==0.26.19",
   "typer>=0.19.2",
   "websockets>=15.0.1",
 ]
 
 [project.optional-dependencies]
-auth = ["softmax-cli==0.26.18"]
+auth = ["softmax-cli==0.26.19"]
 examples = ["fastapi>=0.115.0", "pyarrow>=16.1.0", "uvicorn>=0.34.0"]
 test = [
   "fastapi>=0.115.0",
@@ -87,7 +87,7 @@ testpaths = ["tests"]
 markers = ["slow: marks tests as slow"]
 
 [tool.uv.sources]
-softmax-cli = { workspace = true }
+softmax-cli = {git = "https://github.com/Metta-AI/softmax-cli.git"}
 
 [tool.ruff]
 extend = "../../.ruff.toml"

--- a/src/coworld/cli.py
+++ b/src/coworld/cli.py
@@ -344,14 +344,46 @@ def images(
 
 @app.command("upload-coworld")
 def upload_coworld(
-    manifest_path: Annotated[Path, typer.Argument(help="Path to coworld_manifest.json.")],
+    manifest_path: Annotated[Path | None, typer.Argument(help="Path to coworld_manifest.json.")] = None,
+    base_coworld: Annotated[
+        str | None,
+        typer.Option(
+            "--from-coworld",
+            help="Uploaded Coworld ID or canonical name to use as the base manifest for a partial update.",
+        ),
+    ] = None,
+    version: Annotated[
+        str | None,
+        typer.Option("--version", help="Override game.version before upload."),
+    ] = None,
+    set_updates: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--set",
+            help="Set a manifest field as PATH=VALUE; VALUE is JSON-decoded when possible. Repeatable.",
+        ),
+    ] = None,
+    image_updates: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--image",
+            help=(
+                "Set a runnable image as TARGET=IMAGE. TARGET can be game, a role, role.id, role[index], "
+                "or a full path ending in .image. Repeatable."
+            ),
+        ),
+    ] = None,
     server: Annotated[str, typer.Option("--server", help="Observatory API server URL.")] = DEFAULT_SUBMIT_SERVER,
     timeout_seconds: Annotated[float, typer.Option("--timeout-seconds", min=1.0)] = 60.0,
 ) -> None:
     upload_coworld_cmd(
         manifest_path,
+        base_coworld=base_coworld,
         server=server,
         timeout_seconds=timeout_seconds,
+        version=version,
+        set_updates=set_updates,
+        image_updates=image_updates,
     )
 
 

--- a/src/coworld/upload.py
+++ b/src/coworld/upload.py
@@ -11,10 +11,11 @@ import subprocess
 import tarfile
 import tempfile
 from base64 import b64encode
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Iterator, Self
 from uuid import UUID
 
 import httpx
@@ -24,8 +25,12 @@ from pydantic import BaseModel
 from coworld.certifier import certify_coworld, load_coworld_package
 from coworld.config import DEFAULT_SUBMIT_SERVER
 from coworld.image_refs import is_mutable_registry_image_ref
+from coworld.manifest_validation import validate_coworld_manifest_game_configs
+from coworld.schema_validation import validate_json_schema
+from coworld.types import MANIFEST_ROLE_SECTIONS, CoworldManifest, coworld_manifest_schema
 
 _LOCAL_TAG_SEPARATOR_RE = re.compile(r"[^a-z0-9._-]+")
+_IMAGE_ID_RE = re.compile(r"^img_[A-Za-z0-9_-]+$")
 DOWNLOAD_AGENTS_MD = """# AGENTS.md
 
 Guidance for coding agents working from this downloaded Coworld package.
@@ -394,16 +399,25 @@ def upload_coworld(
     *,
     server: str = DEFAULT_SUBMIT_SERVER,
     timeout_seconds: float = 60.0,
+    version: str | None = None,
+    set_updates: list[str] | None = None,
+    image_updates: list[str] | None = None,
 ) -> CoworldUploadResult:
     package = load_coworld_package(manifest_path)
-    _reject_mutable_registry_image_refs(package.manifest.model_dump(by_alias=True, exclude_none=True))
-    certify_coworld(package.manifest_path, timeout_seconds=timeout_seconds)
+    manifest = package.manifest.model_dump(by_alias=True, exclude_none=True)
+    has_manifest_overrides = version is not None or bool(set_updates) or bool(image_updates)
+    _apply_manifest_updates(manifest, version=version, set_updates=set_updates, image_updates=image_updates)
+    if has_manifest_overrides:
+        _validate_manifest_document(manifest)
+    _reject_mutable_registry_image_refs(manifest)
+    if has_manifest_overrides:
+        with _temporary_manifest_path(manifest) as cert_manifest_path:
+            certify_coworld(cert_manifest_path, timeout_seconds=timeout_seconds)
+    else:
+        certify_coworld(package.manifest_path, timeout_seconds=timeout_seconds)
 
     with CoworldUploadClient.from_login(server_url=server) as client:
-        upload_manifest = _manifest_with_softmax_image_ids(
-            client,
-            package.manifest.model_dump(by_alias=True, exclude_none=True),
-        )
+        upload_manifest = _manifest_with_softmax_image_ids(client, manifest)
         response = client.upload_manifest(upload_manifest)
 
     return CoworldUploadResult(
@@ -414,6 +428,193 @@ def upload_coworld(
         size_bytes=response.size_bytes,
         canonical=response.canonical,
     )
+
+
+def upload_coworld_update(
+    coworld_ref: str,
+    *,
+    server: str = DEFAULT_SUBMIT_SERVER,
+    version: str | None = None,
+    set_updates: list[str] | None = None,
+    image_updates: list[str] | None = None,
+) -> CoworldUploadResult:
+    if version is None and not set_updates and not image_updates:
+        raise ValueError("--from-coworld requires --version, --set, or --image")
+
+    coworld = download_coworld(coworld_ref, server=server)
+    manifest = copy.deepcopy(coworld.manifest)
+    _apply_manifest_updates(manifest, version=version, set_updates=set_updates, image_updates=image_updates)
+    _validate_manifest_document(manifest)
+    _reject_mutable_registry_image_refs(manifest)
+
+    with CoworldUploadClient.from_login(server_url=server) as client:
+        upload_manifest = _manifest_with_softmax_image_ids(client, manifest)
+        response = client.upload_manifest(upload_manifest)
+
+    return CoworldUploadResult(
+        id=response.id,
+        name=response.name,
+        version=response.version,
+        manifest_hash=response.manifest_hash,
+        size_bytes=response.size_bytes,
+        canonical=response.canonical,
+    )
+
+
+@contextmanager
+def _temporary_manifest_path(manifest: dict[str, object]) -> Iterator[Path]:
+    with tempfile.TemporaryDirectory(prefix="coworld-upload-manifest-") as temp_dir:
+        manifest_path = Path(temp_dir) / "coworld_manifest.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        yield manifest_path
+
+
+def _validate_manifest_document(manifest: dict[str, object]) -> None:
+    validate_json_schema(manifest, coworld_manifest_schema())
+    typed_manifest = CoworldManifest.model_validate(manifest)
+    validate_coworld_manifest_game_configs(typed_manifest)
+
+
+def _apply_manifest_updates(
+    manifest: dict[str, object],
+    *,
+    version: str | None,
+    set_updates: list[str] | None,
+    image_updates: list[str] | None,
+) -> None:
+    if version is not None:
+        _set_manifest_path_value(manifest, "game.version", version)
+    for update in set_updates or []:
+        path, value = _parse_field_update(update)
+        _set_manifest_path_value(manifest, path, value)
+    for update in image_updates or []:
+        target, image = _parse_image_update(update)
+        _set_manifest_image(manifest, target, image)
+
+
+def _parse_field_update(update: str) -> tuple[str, object]:
+    path, separator, raw_value = update.partition("=")
+    if not separator or not path:
+        raise ValueError(f"Expected PATH=VALUE for --set, got: {update}")
+    try:
+        value: object = json.loads(raw_value)
+    except json.JSONDecodeError:
+        value = raw_value
+    return path, value
+
+
+def _parse_image_update(update: str) -> tuple[str, str]:
+    target, separator, image = update.partition("=")
+    if not separator or not target or not image:
+        raise ValueError(f"Expected TARGET=IMAGE for --image, got: {update}")
+    return target, image
+
+
+def _set_manifest_image(manifest: dict[str, object], target: str, image: str) -> None:
+    if target in {"game", "game.runnable"}:
+        _set_manifest_path_value(manifest, "game.runnable.image", image)
+        return
+    if target == "game.runnable.image" or target.endswith(".image"):
+        _set_manifest_path_value(manifest, target, image)
+        return
+
+    role, selector = _split_image_target(target)
+    if role == "game":
+        if selector is not None:
+            raise ValueError("game image target does not accept a selector")
+        _set_manifest_path_value(manifest, "game.runnable.image", image)
+        return
+
+    entries = manifest.get(role)
+    if not isinstance(entries, list):
+        raise ValueError(f"Manifest role section is not a list: {role}")
+    if selector is None:
+        if len(entries) != 1:
+            raise ValueError(f"--image {role}=... is ambiguous because {role} has {len(entries)} entries")
+        entry = entries[0]
+    elif selector.isdigit():
+        index = int(selector)
+        try:
+            entry = entries[index]
+        except IndexError as exc:
+            raise ValueError(f"No {role} entry at index {index}") from exc
+    else:
+        matches = [entry for entry in entries if isinstance(entry, dict) and entry.get("id") == selector]
+        if len(matches) != 1:
+            raise ValueError(f"No unique {role} entry with id {selector!r}")
+        entry = matches[0]
+    if not isinstance(entry, dict) or "image" not in entry:
+        raise ValueError(f"Manifest target is not a runnable image field: {target}")
+    entry["image"] = image
+
+
+def _split_image_target(target: str) -> tuple[str, str | None]:
+    role_sections = {"game", *MANIFEST_ROLE_SECTIONS}
+    if "[" in target:
+        parts = _parse_manifest_path(target)
+        if len(parts) == 2 and isinstance(parts[0], str) and isinstance(parts[1], int) and parts[0] in role_sections:
+            return parts[0], str(parts[1])
+    role, separator, selector = target.partition(".")
+    if role not in role_sections:
+        raise ValueError(f"Unknown image target role: {role}")
+    return role, selector if separator else None
+
+
+def _set_manifest_path_value(manifest: dict[str, object], path: str, value: object) -> None:
+    parts = _parse_manifest_path(path)
+    if not parts:
+        raise ValueError("Manifest path must not be empty")
+    current: object = manifest
+    for part in parts[:-1]:
+        current = _get_manifest_path_part(current, part, path)
+    last = parts[-1]
+    if isinstance(last, int):
+        if not isinstance(current, list):
+            raise ValueError(f"Manifest path {path!r} expected a list before index {last}")
+        try:
+            current[last] = value
+        except IndexError as exc:
+            raise ValueError(f"Manifest path {path!r} index out of range: {last}") from exc
+        return
+    if not isinstance(current, dict):
+        raise ValueError(f"Manifest path {path!r} expected an object before {last!r}")
+    current[last] = value
+
+
+def _get_manifest_path_part(value: object, part: str | int, path: str) -> object:
+    if isinstance(part, int):
+        if not isinstance(value, list):
+            raise ValueError(f"Manifest path {path!r} expected a list before index {part}")
+        try:
+            return value[part]
+        except IndexError as exc:
+            raise ValueError(f"Manifest path {path!r} index out of range: {part}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"Manifest path {path!r} expected an object before {part!r}")
+    if part not in value:
+        raise ValueError(f"Manifest path {path!r} is missing key {part!r}")
+    return value[part]
+
+
+def _parse_manifest_path(path: str) -> list[str | int]:
+    parts: list[str | int] = []
+    for raw_part in path.split("."):
+        if not raw_part:
+            raise ValueError(f"Invalid manifest path: {path}")
+        name, bracket, rest = raw_part.partition("[")
+        if name:
+            parts.append(name)
+        while bracket:
+            index_text, close, rest = rest.partition("]")
+            if not close or not index_text.isdigit():
+                raise ValueError(f"Invalid manifest path: {path}")
+            parts.append(int(index_text))
+            if not rest:
+                break
+            bracket, rest = rest[0], rest[1:]
+            if bracket != "[":
+                raise ValueError(f"Invalid manifest path: {path}")
+    return parts
 
 
 def _reject_mutable_registry_image_refs(manifest: dict[str, object]) -> None:
@@ -459,15 +660,36 @@ def _load_current_cogames_token(*, server_url: str) -> str | None:
 
 
 def upload_coworld_cmd(
-    manifest_path: Path,
+    manifest_path: Path | None = None,
+    *,
+    base_coworld: str | None = None,
     server: str = DEFAULT_SUBMIT_SERVER,
     timeout_seconds: float = 60.0,
+    version: str | None = None,
+    set_updates: list[str] | None = None,
+    image_updates: list[str] | None = None,
 ) -> None:
-    result = upload_coworld(
-        manifest_path,
-        server=server,
-        timeout_seconds=timeout_seconds,
-    )
+    if base_coworld is not None:
+        if manifest_path is not None:
+            raise typer.BadParameter("MANIFEST_PATH cannot be combined with --from-coworld")
+        result = upload_coworld_update(
+            base_coworld,
+            server=server,
+            version=version,
+            set_updates=set_updates,
+            image_updates=image_updates,
+        )
+    else:
+        if manifest_path is None:
+            raise typer.BadParameter("MANIFEST_PATH is required unless --from-coworld is set")
+        result = upload_coworld(
+            manifest_path,
+            server=server,
+            timeout_seconds=timeout_seconds,
+            version=version,
+            set_updates=set_updates,
+            image_updates=image_updates,
+        )
     typer.echo(f"Upload complete: {result.name}:{result.version}")
     typer.echo(f"Coworld: {result.id}")
     typer.echo(f"Manifest hash: {result.manifest_hash}")
@@ -615,10 +837,17 @@ def _manifest_with_softmax_image_ids(client: CoworldUploadClient, manifest: dict
     replacements = {
         image: _upload_container_image(client, image).id
         for image in sorted({runnable["image"] for runnable in _manifest_image_fields(upload_manifest)})
+        if not _is_uploaded_image_id(image)
     }
     for runnable in _manifest_image_fields(upload_manifest):
-        runnable["image"] = replacements[runnable["image"]]
+        image = runnable["image"]
+        if image in replacements:
+            runnable["image"] = replacements[image]
     return upload_manifest
+
+
+def _is_uploaded_image_id(image: str) -> bool:
+    return _IMAGE_ID_RE.match(image) is not None
 
 
 def _manifest_image_fields(value: object) -> list[dict[str, Any]]:

--- a/tests/test_coworld_upload_cli.py
+++ b/tests/test_coworld_upload_cli.py
@@ -19,6 +19,7 @@ from coworld.upload import (
     _local_image_client_hash,
     _local_image_tag,
     _manifest_image_fields,
+    _manifest_with_softmax_image_ids,
     _manifest_with_local_images,
     _push_archive_to_registry,
     upload_coworld,
@@ -291,6 +292,237 @@ def test_upload_coworld_command_certifies_before_uploading(
     assert "Manifest hash: sha256:manifest-hash" in result.output
     assert "Canonical: yes" in result.output
     assert certification_calls == [(manifest_path.resolve(), 60.0)]
+
+
+def test_upload_coworld_command_overrides_version(
+    tmp_path: Path,
+    httpserver: HTTPServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    image_id = "img_00000000-0000-0000-0000-000000000022"
+    certified_versions: list[str] = []
+
+    def fake_certify(path: Path, *, timeout_seconds: float) -> None:
+        del timeout_seconds
+        certified_versions.append(json.loads(path.read_text(encoding="utf-8"))["game"]["version"])
+
+    monkeypatch.setattr("coworld.upload.certify_coworld", fake_certify)
+    monkeypatch.setattr("coworld.upload._local_image_client_hash", lambda image: "sha256:client-hash")
+    monkeypatch.setattr("coworld.upload._push_container_image", lambda source_image, push_info: None)
+    httpserver.expect_request("/observatory/v2/container_images/upload", method="POST").respond_with_json(
+        {
+            "image": {
+                "id": image_id,
+                "name": "unit-test-runtime",
+                "version": 1,
+                "client_hash": "sha256:client-hash",
+                "status": "ready",
+                "image_uri": "123456789012.dkr.ecr.us-east-1.amazonaws.com/coworld/user/unit-test-runtime@sha256:digest",
+                "image_digest": "sha256:digest",
+            },
+            "pre_signed_info": None,
+        }
+    )
+    httpserver.expect_request("/observatory/v2/container_images/upload", method="POST").respond_with_json(
+        {
+            "image": {
+                "id": "img_00000000-0000-0000-0000-000000000023",
+                "name": "graders-default",
+                "version": 1,
+                "client_hash": "sha256:client-hash",
+                "status": "ready",
+                "image_uri": "123456789012.dkr.ecr.us-east-1.amazonaws.com/coworld/user/graders-default@sha256:digest",
+                "image_digest": "sha256:digest",
+            },
+            "pre_signed_info": None,
+        }
+    )
+    httpserver.expect_request("/observatory/v2/coworlds/upload", method="POST").respond_with_json(
+        {
+            "id": "cow_00000000-0000-0000-0000-000000000012",
+            "name": "unit-test-game",
+            "version": "0.2.0",
+            "manifest": _manifest_with_image(image_id),
+            "manifest_hash": "sha256:manifest-hash",
+            "size_bytes": 1234,
+            "canonical": True,
+        }
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "upload-coworld",
+            str(manifest_path),
+            "--version",
+            "0.2.0",
+            "--server",
+            httpserver.url_for(""),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert certified_versions == ["0.2.0"]
+    upload_req = next(req for req, _ in httpserver.log if req.path == "/observatory/v2/coworlds/upload")
+    assert upload_req.get_json()["manifest"]["game"]["version"] == "0.2.0"
+
+
+def test_upload_coworld_from_existing_manifest_updates_field_without_images(
+    httpserver: HTTPServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coworld_id = "cow_00000000-0000-0000-0000-000000000013"
+    existing_image_id = "img_00000000-0000-0000-0000-000000000099"
+    manifest = _manifest_with_image(existing_image_id)
+
+    monkeypatch.setattr("coworld.upload.certify_coworld", lambda *_args, **_kwargs: pytest.fail("certified manifest"))
+    monkeypatch.setattr(
+        "coworld.upload._local_image_client_hash",
+        lambda image: pytest.fail(f"hashed unchanged image {image}"),
+    )
+    httpserver.expect_request(f"/observatory/v2/coworlds/{coworld_id}", method="GET").respond_with_json(
+        {
+            "id": coworld_id,
+            "name": "unit-test-game",
+            "version": "0.1.0",
+            "manifest": manifest,
+            "manifest_hash": "sha256:old-manifest-hash",
+            "size_bytes": 1234,
+            "canonical": True,
+        }
+    )
+    httpserver.expect_request("/observatory/v2/coworlds/upload", method="POST").respond_with_json(
+        {
+            "id": coworld_id,
+            "name": "unit-test-game",
+            "version": "0.2.0",
+            "manifest": manifest,
+            "manifest_hash": "sha256:new-manifest-hash",
+            "size_bytes": 1250,
+            "canonical": True,
+        }
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "upload-coworld",
+            "--from-coworld",
+            coworld_id,
+            "--version",
+            "0.2.0",
+            "--set",
+            "game.owner=new-owner@softmax.com",
+            "--server",
+            httpserver.url_for(""),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    upload_req = next(req for req, _ in httpserver.log if req.path == "/observatory/v2/coworlds/upload")
+    uploaded_manifest = upload_req.get_json()["manifest"]
+    assert uploaded_manifest["game"]["version"] == "0.2.0"
+    assert uploaded_manifest["game"]["owner"] == "new-owner@softmax.com"
+    assert uploaded_manifest["game"]["runnable"]["image"] == existing_image_id
+    assert uploaded_manifest["player"][0]["image"] == existing_image_id
+
+
+def test_upload_coworld_from_existing_manifest_updates_one_role_image(
+    httpserver: HTTPServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coworld_id = "cow_00000000-0000-0000-0000-000000000014"
+    existing_image_id = "img_00000000-0000-0000-0000-000000000099"
+    commissioner_image_id = "img_00000000-0000-0000-0000-000000000100"
+    manifest = _manifest_with_image(existing_image_id)
+    manifest["commissioner"] = [
+        {
+            "id": "round-robin",
+            "name": "Round Robin Commissioner",
+            "description": "Default commissioner.",
+            "type": "commissioner",
+            "image": existing_image_id,
+        }
+    ]
+    hashed_images: list[str] = []
+
+    def fake_hash(image: str) -> str:
+        hashed_images.append(image)
+        return "sha256:commissioner-hash"
+
+    monkeypatch.setattr("coworld.upload.certify_coworld", lambda *_args, **_kwargs: pytest.fail("certified manifest"))
+    monkeypatch.setattr("coworld.upload._local_image_client_hash", fake_hash)
+    monkeypatch.setattr("coworld.upload._push_container_image", lambda source_image, push_info: None)
+    httpserver.expect_request(f"/observatory/v2/coworlds/{coworld_id}", method="GET").respond_with_json(
+        {
+            "id": coworld_id,
+            "name": "unit-test-game",
+            "version": "0.1.0",
+            "manifest": manifest,
+            "manifest_hash": "sha256:old-manifest-hash",
+            "size_bytes": 1234,
+            "canonical": True,
+        }
+    )
+    httpserver.expect_request(
+        "/observatory/v2/container_images/upload",
+        method="POST",
+        json={"name": "unit-test-commissioner", "client_hash": "sha256:commissioner-hash"},
+    ).respond_with_json(
+        {
+            "image": {
+                "id": commissioner_image_id,
+                "name": "unit-test-commissioner",
+                "version": 1,
+                "client_hash": "sha256:commissioner-hash",
+                "status": "ready",
+                "image_uri": "123456789012.dkr.ecr.us-east-1.amazonaws.com/coworld/user/unit-test-commissioner@sha256:digest",
+                "image_digest": "sha256:digest",
+            },
+            "pre_signed_info": None,
+        }
+    )
+    httpserver.expect_request("/observatory/v2/coworlds/upload", method="POST").respond_with_json(
+        {
+            "id": coworld_id,
+            "name": "unit-test-game",
+            "version": "0.2.0",
+            "manifest": manifest,
+            "manifest_hash": "sha256:new-manifest-hash",
+            "size_bytes": 1250,
+            "canonical": True,
+        }
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "upload-coworld",
+            "--from-coworld",
+            coworld_id,
+            "--version",
+            "0.2.0",
+            "--image",
+            "commissioner=unit-test-commissioner:latest",
+            "--server",
+            httpserver.url_for(""),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert hashed_images == ["unit-test-commissioner:latest"]
+    upload_req = next(req for req, _ in httpserver.log if req.path == "/observatory/v2/coworlds/upload")
+    uploaded_manifest = upload_req.get_json()["manifest"]
+    assert uploaded_manifest["game"]["runnable"]["image"] == existing_image_id
+    assert uploaded_manifest["commissioner"][0]["image"] == commissioner_image_id
+
+
+def test_manifest_with_softmax_image_ids_keeps_existing_image_ids() -> None:
+    manifest = _manifest_with_image("img_00000000-0000-0000-0000-000000000099")
+    uploaded = _manifest_with_softmax_image_ids(cast(CoworldUploadClient, object()), manifest)
+
+    assert uploaded["game"]["runnable"]["image"] == "img_00000000-0000-0000-0000-000000000099"
 
 
 def test_upload_coworld_surfaces_server_error_detail(


### PR DESCRIPTION
## Summary
- add upload-coworld --from-coworld for partial updates based on an uploaded manifest
- support --version, --set PATH=VALUE, and --image TARGET=IMAGE overrides
- keep existing img_... image IDs unchanged so only newly supplied image refs are uploaded
- document partial update examples in the Coworld cookbook

## Tests
- uv run --extra test pytest tests/test_coworld_upload_cli.py -q
- uv run --extra test python -m py_compile src/coworld/upload.py src/coworld/cli.py tests/test_coworld_upload_cli.py

## Notes
- Ruff could not run in this worktree because pyproject.toml extends ../../.ruff.toml, which resolves to missing /home/.ruff.toml in this checkout layout.