### PR TITLE
Add player artifact upload skill and contract docs

### DIFF
--- a/.claude/skills/upload-player-artifact/SKILL.md
+++ b/.claude/skills/upload-player-artifact/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: upload-player-artifact
+description: "Use when a Coworld player needs to upload a debug artifact at episode end."
+---
+
+# Upload Player Artifact
+
+Help a Coworld player policy upload a single debug artifact at the end of an episode, separate from
+logs, for profiling and post-hoc analysis. The runner hands each player a presigned upload URL; the
+player uploads itself.
+
+## Contract
+
+The runner injects one environment variable into the player container:
+
+- `COWORLD_PLAYER_ARTIFACT_UPLOAD_URL` — where this player slot uploads its artifact.
+  - Hosted: a presigned `https://` `PUT` URL (already authorized, no auth header needed).
+  - Local: a `file://` path into the mounted workspace.
+  - Absent: the player skips uploading. Always treat this as optional.
+
+Rules the player must follow:
+
+- Upload exactly one object. There is one URL per player slot.
+- Maximum size 200 MB. Larger uploads are rejected.
+- Use HTTP `PUT` with header `Content-Type: application/zip`. No auth header (the URL is presigned).
+- For `file://` URLs, just write the bytes to that path (create parent dirs).
+- Upload before the container is torn down. The player may upload any time, but once the game
+  finishes the container stays alive only for a bounded teardown window. An upload that does not
+  finish before teardown is lost. The platform never blocks teardown waiting for an upload.
+- A missing or failed artifact never fails an otherwise successful episode. Do not crash the player
+  on upload failure unless you want the episode to fail.
+
+See `src/coworld/docs/artifacts/PLAYER_ARTIFACT.md` for the full artifact contract and
+`src/coworld/docs/roles/PLAYER.md` for the player role.
+
+## Building the zip
+
+The artifact is a single `.zip`. The platform stores and serves the bytes as-is and never unzips
+them, so the player decides what goes inside. Bundle whatever you want: parquet, sqlite, csv, json,
+or raw trace files. The `.zip` extension is a storage convention, not an enforced format.
+
+Two profiling approaches this enables:
+
+- Sampling profiler: dump all per-step state into one file, zip it, upload. Useful early, becomes
+  noise once you know what matters.
+- Tracing profiler: record only specific named events. Better for optimization once you know what
+  to look for.
+
+Keep the zip well under 200 MB. If a sampling dump is too large, downsample, compress columns
+(parquet), or switch to tracing specific events.
+
+## Steps
+
+1. Read `COWORLD_PLAYER_ARTIFACT_UPLOAD_URL` from the environment. If it is empty or unset, skip the
+   upload entirely and return.
+2. Collect debug data into one or more in-memory files while the episode runs.
+3. At episode end (after the final game message, before exiting), build a single `.zip` of those
+   files in memory.
+4. `PUT` the zip bytes to the URL with `Content-Type: application/zip`. For `file://` URLs, write
+   the bytes to the path instead. Finish before the container exits.
+5. Do not raise on upload failure unless losing the artifact should fail the episode; log and move
+   on, since a missing artifact never fails an otherwise successful episode.
+
+## Python example
+
+Players in this repo are Python containers. The `python:3.12-slim` Coworld image already ships
+`requests`, `pyarrow`, and `websockets`. This helper covers both `https://` (PUT) and `file://`
+(local) URLs:
+
+```python
+import io
+import os
+import zipfile
+from urllib.parse import unquote, urlparse
+
+import requests
+
+
+def upload_player_artifact(files: dict[str, bytes]) -> None:
+    """Zip `files` (name -> bytes) and upload to the per-slot artifact URL, if set.
+
+    Safe to call unconditionally: a missing env var or failed upload is ignored, since a
+    missing artifact never fails the episode.
+    """
+    url = os.environ.get("COWORLD_PLAYER_ARTIFACT_UPLOAD_URL")
+    if not url:
+        return  # No URL: artifact upload is disabled for this run.
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, data in files.items():
+            archive.writestr(name, data)
+    payload = buffer.getvalue()
+
+    parsed = urlparse(url)
+    if parsed.scheme == "file":
+        path = unquote(parsed.path)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as handle:
+            handle.write(payload)
+        return
+
+    # Presigned PUT. No auth header: the URL is already authorized.
+    response = requests.put(url, data=payload, headers={"Content-Type": "application/zip"}, timeout=60)
+    response.raise_for_status()
+```
+
+Call it at episode end, for example after the player receives the `final` message:
+
+```python
+async for raw_message in websocket:
+    message = json.loads(raw_message)
+    if message["type"] == "final":
+        upload_player_artifact({
+            "trace.parquet": trace_table_bytes,   # tracing profiler output
+            "summary.json": summary_json_bytes,
+        })
+        return
+    ...
+```
+
+If you prefer no third-party dependency, the runner's own helper
+`src/coworld/runner/io.py` (`upload_data(url, data, content_type="application/zip")`) does the same
+PUT with retries using only the standard library.
+
+## Nim example
+
+There is no Nim player in this repo today, so a Nim player would be net-new. If you write one, use
+`curly` (the Softmax-standard Nim HTTP client) for the upload and `zippy` for the zip. Handle the
+timeout and `response.code` explicitly.
+
+```nim
+import std/[os, strutils], curly, zippy
+
+let curl = newCurlPool(1)
+
+proc uploadPlayerArtifact(files: seq[(string, string)]) =
+  ## Zip `files` (name, contents) and upload to the per-slot artifact URL, if set.
+  let url = getEnv("COWORLD_PLAYER_ARTIFACT_UPLOAD_URL")
+  if url.len == 0:
+    return                       # No URL: artifact upload is disabled for this run.
+
+  # Build the zip in memory. ZipArchive maps entry name -> contents.
+  var archive = ZipArchive()
+  for (name, contents) in files:
+    archive.contents[name] = ArchiveEntry(contents: contents)
+  let payload = archive.writeZipArchive()
+
+  if url.startsWith("file://"):
+    let path = url[len("file://") .. ^1]
+    createDir(path.parentDir())
+    writeFile(path, payload)
+    return
+
+  # Presigned PUT. No auth header: the URL is already authorized.
+  let response = curl.put(
+    url,
+    @[("Content-Type", "application/zip")],
+    payload,
+    60.0'f32
+  )
+  if response.code != 200:
+    # A missing artifact never fails the episode; log instead of crashing.
+    echo "artifact upload failed: HTTP ", response.code, " ", response.body
+```
+
+## Review checklist
+
+- The player reads `COWORLD_PLAYER_ARTIFACT_UPLOAD_URL` and skips cleanly when it is absent.
+- Exactly one `.zip` is uploaded per slot, well under 200 MB.
+- The PUT sets `Content-Type: application/zip` and no auth header.
+- `file://` URLs are handled for local runs (write bytes, create parent dirs).
+- The upload completes before the player exits / the container is torn down.
+- Upload failure is logged, not fatal (unless failing the episode is intended).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,13 @@ dependencies = [
   "referencing>=0.36.2",
   "requests>=2.32",
   "rich>=13.7.0",
-  "softmax-cli==0.26.16",
+  "softmax-cli==0.26.17",
   "typer>=0.19.2",
   "websockets>=15.0.1",
 ]
 
 [project.optional-dependencies]
-auth = ["softmax-cli==0.26.16"]
+auth = ["softmax-cli==0.26.17"]
 examples = ["fastapi>=0.115.0", "pyarrow>=16.1.0", "uvicorn>=0.34.0"]
 test = [
   "fastapi>=0.115.0",
@@ -98,7 +98,7 @@ testpaths = ["tests"]
 markers = ["slow: marks tests as slow"]
 
 [tool.uv.sources]
-softmax-cli = { workspace = true }
+softmax-cli = {git = "https://github.com/Metta-AI/softmax-cli.git"}
 
 [tool.ruff]
 extend = "../../.ruff.toml"

--- a/src/coworld/docs/artifacts/EPISODE_BUNDLE.md
+++ b/src/coworld/docs/artifacts/EPISODE_BUNDLE.md
@@ -21,6 +21,7 @@ A bundle is a zip containing some subset of the following entries plus a `manife
 | `error_info`  | `error_info.json` (only present if the episode failed)                 | [Error info](ERROR_INFO.md) from `ERROR_INFO_URI`     |
 | `game_logs`   | `logs/game.stdout.log`, `logs/game.stderr.log`                         | [Game logs](GAME_LOGS.md) from [debug archive](DEBUG_ARCHIVE.md) / local logs |
 | `player_logs` | `logs/policy_agent_{slot}.log` (subject to access control — see below) | [Player logs](PLAYER_LOGS.md) from `POLICY_LOG_URLS` / local logs |
+| `player_artifact` | `artifacts/policy_artifact_{slot}.zip` (subject to access control — see below) | [Player artifact](PLAYER_ARTIFACT.md) from `PLAYER_ARTIFACT_UPLOAD_URLS` / local workspace |
 
 The bundle stores `replay.json` uncompressed since the outer zip already compresses. The runner's local workspace
 contains a single `replay` file with the exact bytes the game container wrote; the hosted upload path zlib-compresses
@@ -101,6 +102,8 @@ additional rule for player logs:
 - **`results`, `replay`, `error_info`, `game_logs`**: anyone with episode access can include them.
 - **`player_logs`**: by default, the bundle includes only the logs for player slots controlled by policy versions
   the requester owns. Softmax-internal requesters may receive all player logs.
+- **`player_artifact`**: same policy-scoped rule as `player_logs` — by default only the artifacts for player slots
+  the requester owns, with Softmax-internal requesters receiving all.
 
 > **Game authors:** game container stdout and stderr are surfaced to *anyone* with episode access via the
 > `game_logs` token. Do not write secrets, private credentials, or other confidential information to those streams.

--- a/src/coworld/docs/artifacts/PLAYER_ARTIFACT.md
+++ b/src/coworld/docs/artifacts/PLAYER_ARTIFACT.md
@@ -1,0 +1,62 @@
+# Player Artifact
+
+A **player artifact** is an optional file a player uploads at the end of an episode to save debug data —
+separate from [player logs](PLAYER_LOGS.md). It is intended for profiling and post-hoc analysis where stdout/stderr
+logs are too large or too unstructured (logs routinely grow to gigabytes).
+
+## Producer
+
+The player container uploads the artifact itself. The runner hands each player a single presigned upload URL via the
+`COWORLD_PLAYER_ARTIFACT_UPLOAD_URL` environment variable:
+
+- local runner: a `file://` URL into the workspace (the workspace is mounted into the player container at
+  `/coworld-artifact`), collected as `policy_artifact_{slot}.zip`;
+- hosted runner: a presigned `PUT` URL derived from `PLAYER_ARTIFACT_UPLOAD_URLS` (a JSON object mapping slot -> URL),
+  forwarded into the player pod by the worker.
+
+If the variable is absent, the player skips uploading. The platform never reaches into the player container's
+filesystem; the player must perform the upload.
+
+## Upload window
+
+The player may upload at any time. Once the game finishes, the player container/pod stays alive only for a bounded
+teardown timeout — the player must complete the upload before teardown or the artifact is lost. The platform does not
+block teardown waiting for an upload.
+
+## Contract
+
+- Exactly one object per player slot.
+- Maximum size: 200 MB.
+- Format: a `.zip`. The player may bundle whatever it wants inside (parquet, sqlite, csv, json, trace files). The
+  platform stores and serves the bytes as-is and does not unzip them. The `.zip` extension is a storage convention,
+  not an enforced format.
+- Local filename: `policy_artifact_{slot}.zip` in the workspace root.
+- Hosted key: `jobs/{job_id}/policy_artifact_{slot}.zip`.
+- Content type: `application/zip`.
+- Purpose: profiling and debugging only.
+
+The two profiling approaches this enables:
+
+- **Sampling profiler** (records everything): dump all per-step state into a file, zip, upload. Useful initially but
+  becomes noise.
+- **Tracing profiler** (records specific events): record only named events. Better for optimization once you know
+  what to look for.
+
+Missing artifacts do not fail an otherwise successful episode. Results and replay upload remain the
+success-critical artifacts.
+
+## Visibility
+
+Player artifacts are policy-scoped by default, matching player logs: a requester receives only artifacts for
+slots controlled by policy versions they own, unless the requester has internal access.
+
+Serving routes:
+
+- `GET /jobs/{job_id}/policy-artifact` lists the slots that uploaded an artifact.
+- `GET /jobs/{job_id}/policy-artifact/{agent_idx}` returns the `.zip` for a slot.
+
+## See Also
+
+- [Player logs](PLAYER_LOGS.md) for stdout/stderr diagnostics.
+- [Player role](../roles/PLAYER.md) for the producer contract.
+- [Episode bundle](EPISODE_BUNDLE.md) for access-controlled bundled consumption.

--- a/src/coworld/docs/artifacts/README.md
+++ b/src/coworld/docs/artifacts/README.md
@@ -11,6 +11,7 @@ consumes something; artifact pages describe the thing itself.
 | [Replay](REPLAY.md) | Game | Local `replay`, hosted `REPLAY_URI`, episode bundle `replay` token |
 | [Game logs](GAME_LOGS.md) | Game container / runner | Local `logs/game.*.log`, hosted `DEBUG_URI`, episode bundle `game_logs` token |
 | [Player logs](PLAYER_LOGS.md) | Player containers / runner | Local `logs/policy_agent_{slot}.log`, hosted `POLICY_LOG_URLS`, episode bundle `player_logs` token |
+| [Player artifact](PLAYER_ARTIFACT.md) | Player containers | Local `policy_artifact_{slot}.zip`, hosted `PLAYER_ARTIFACT_UPLOAD_URLS`, episode bundle `player_artifact` token |
 | [Debug archive](DEBUG_ARCHIVE.md) | Hosted runner | Hosted `DEBUG_URI` aggregate log zip |
 | [Error info](ERROR_INFO.md) | Hosted runner | Hosted `ERROR_INFO_URI`, episode bundle `error_info` token |
 | [Episode bundle](EPISODE_BUNDLE.md) | Bundling layer | On-demand zip assembled for post-episode consumers |

--- a/src/coworld/docs/roles/PLAYER.md
+++ b/src/coworld/docs/roles/PLAYER.md
@@ -31,6 +31,17 @@ The player runnable is a short-lived container started by the episode runner onc
   slot/token pair; a player must not attempt to control other slots.
 - Exit cleanly when the episode ends.
 
+A player may also, optionally, upload a single artifact at episode end:
+
+- Read `COWORLD_PLAYER_ARTIFACT_UPLOAD_URL` from the environment. When present, it is a destination the player may upload
+  one file to (a presigned `PUT` URL hosted, a `file://` path locally). When absent, the player simply skips uploading.
+- Upload at most one `.zip` (max 200 MB). The player may bundle whatever debug data it wants inside (parquet, sqlite,
+  csv, json, trace files); the platform stores and serves the bytes as-is.
+- Upload before the container is torn down. The player may upload at any time, but once the game finishes the container
+  stays alive only for a bounded teardown window; an upload that does not finish before teardown is lost. The platform
+  does not block teardown waiting for an upload, and a missing artifact never fails an otherwise successful
+  episode. See [player artifact](../artifacts/PLAYER_ARTIFACT.md).
+
 Hosted runs schedule each player runnable with 2 CPU / 2Gi memory baseline (see
 [`GAME.md`](GAME.md#hosted-runtime-resources)).
 
@@ -102,15 +113,20 @@ the image.
 See [`COWORLD_MECHANICS.md`](../../../../../../app_backend/src/metta/app_backend/v2/COWORLD_MECHANICS.md) for the
 container-image mirror mechanic and the distinction between Coworld-bundled images and policy upload images.
 
-## Logging
+## Logging and artifacts
 
 Player runnables produce diagnostic [player logs](../artifacts/PLAYER_LOGS.md) through captured stdout/stderr and, when
 available, optional `COGAME_LOG_URI` posting. Container output is diagnostic only — the source of truth for episode
 success is the game's results and replay artifacts, not player logs.
 
-The player does not receive or create an episode bundle. Its actions are represented in the
-[replay artifact](../artifacts/REPLAY.md), and its container logs may be included as
-[`player_logs`](../artifacts/PLAYER_LOGS.md); see [`artifacts/EPISODE_BUNDLE.md`](../artifacts/EPISODE_BUNDLE.md).
+A player may also upload a [player artifact](../artifacts/PLAYER_ARTIFACT.md): a single `.zip` (max 200 MB) it
+writes to `COWORLD_PLAYER_ARTIFACT_UPLOAD_URL` for post-hoc profiling and analysis, separate from logs. This is the only
+file a player authors directly; it never modifies the game-owned results or replay artifacts.
+
+The player does not receive or assemble an episode bundle. Its actions are represented in the
+[replay artifact](../artifacts/REPLAY.md), its container logs may be included as
+[`player_logs`](../artifacts/PLAYER_LOGS.md), and its uploaded artifact may be included as
+[`player_artifact`](../artifacts/PLAYER_ARTIFACT.md); see [`artifacts/EPISODE_BUNDLE.md`](../artifacts/EPISODE_BUNDLE.md).
 
 ## How it fits with other roles
 
@@ -126,5 +142,6 @@ game's output artifacts after the episode. Players' per-slot actions plus the ga
 - [`COOKBOOK.md`](../../../../COOKBOOK.md) — policy-upload flow, secrets, league submission.
 - [`artifacts/EPISODE_BUNDLE.md`](../artifacts/EPISODE_BUNDLE.md) — how player-related artifacts can be bundled.
 - [`artifacts/PLAYER_LOGS.md`](../artifacts/PLAYER_LOGS.md) — diagnostic logs produced by player containers.
+- [`artifacts/PLAYER_ARTIFACT.md`](../artifacts/PLAYER_ARTIFACT.md) — optional artifact a player uploads at episode end.
 - [`artifacts/REPLAY.md`](../artifacts/REPLAY.md) — replay artifact containing player actions and game state.
 - [`README.md`](../README.md) — full artifact flow.


### PR DESCRIPTION
Adds the upload-player-artifact skill plus the PLAYER_ARTIFACT.md contract docs, ported from the metta monorepo.