### PR TITLE
Wait for hosted smoke after Coworld upload

### DIFF
--- a/src/coworld/cli.py
+++ b/src/coworld/cli.py
@@ -454,6 +454,17 @@ def upload_coworld(
     ] = None,
     server: Annotated[str, typer.Option("--server", help="Observatory API server URL.")] = DEFAULT_SUBMIT_SERVER,
     timeout_seconds: Annotated[float, typer.Option("--timeout-seconds", min=1.0)] = 60.0,
+    wait_hosted_smoke: Annotated[
+        bool,
+        typer.Option(
+            "--wait-hosted-smoke/--no-wait-hosted-smoke",
+            help="Wait for hosted smoke certification after upload and fail if it fails.",
+        ),
+    ] = True,
+    hosted_smoke_timeout_seconds: Annotated[
+        float,
+        typer.Option("--hosted-smoke-timeout-seconds", min=1.0, help="Maximum time to wait for hosted smoke."),
+    ] = 1800.0,
 ) -> None:
     upload_coworld_cmd(
         manifest_path,
@@ -463,6 +474,8 @@ def upload_coworld(
         version=version,
         patch_update=patch_update,
         image_updates=image_updates,
+        wait_for_hosted_smoke=wait_hosted_smoke,
+        hosted_smoke_timeout_seconds=hosted_smoke_timeout_seconds,
     )
 
 

--- a/src/coworld/upload.py
+++ b/src/coworld/upload.py
@@ -10,6 +10,7 @@ import shlex
 import subprocess
 import tarfile
 import tempfile
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -31,6 +32,8 @@ from coworld.types import MANIFEST_ROLE_SECTIONS, CoworldManifest, coworld_manif
 
 _LOCAL_TAG_SEPARATOR_RE = re.compile(r"[^a-z0-9._-]+")
 _IMAGE_ID_RE = re.compile(r"^img_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+_HOSTED_SMOKE_TERMINAL_STATUSES = {"completed", "failed", "canceled", "cancelled"}
+_HOSTED_SMOKE_SUCCESS_STATUSES = {"completed"}
 DOWNLOAD_AGENTS_MD = """# AGENTS.md
 
 Guidance for coding agents working from this downloaded Coworld package.
@@ -186,6 +189,7 @@ class CoworldUploadResult:
     manifest_hash: str
     size_bytes: int
     canonical: bool
+    hosted_smoke_episode_ids: tuple[str, ...] = ()
 
 
 class CoworldUploadClient:
@@ -222,6 +226,21 @@ class CoworldUploadClient:
         _raise_for_status(response)
         return CoworldUploadResponse.model_validate(response.json())
 
+    def list_episode_requests(self, *, limit: int = 1000, offset: int = 0) -> list[dict[str, Any]]:
+        response = self._http_client.get(
+            "/v2/episode-requests",
+            headers=self._headers(),
+            params={"limit": limit, "offset": offset},
+            timeout=60.0,
+        )
+        _raise_for_status(response)
+        page = response.json()
+        if isinstance(page, dict) and isinstance(page.get("entries"), list):
+            return page["entries"]
+        if isinstance(page, list):
+            return page
+        raise RuntimeError("Unexpected episode request list response from server.")
+
     def list_coworlds(self, *, limit: int = 200, offset: int = 0) -> list[CoworldListEntry]:
         response = self._http_client.get(
             "/v2/coworlds",
@@ -243,6 +262,15 @@ class CoworldUploadClient:
             if len(coworlds) < limit:
                 return None
             offset += limit
+
+    def get_coworld(self, coworld_id: str) -> CoworldUploadResponse:
+        response = self._http_client.get(
+            f"/v2/coworlds/{coworld_id}",
+            headers=self._headers(),
+            timeout=120.0,
+        )
+        _raise_for_status(response)
+        return CoworldUploadResponse.model_validate(response.json())
 
     def find_canonical_coworld(self, name: str) -> CoworldListEntry | None:
         target_name = _coworld_name_key(name)
@@ -455,6 +483,9 @@ def upload_coworld(
     *,
     server: str = DEFAULT_SUBMIT_SERVER,
     timeout_seconds: float = 60.0,
+    wait_for_hosted_smoke: bool = False,
+    hosted_smoke_timeout_seconds: float = 1800.0,
+    hosted_smoke_poll_seconds: float = 5.0,
 ) -> CoworldUploadResult:
     package = load_coworld_package(manifest_path)
     manifest = package.manifest.model_dump(by_alias=True, exclude_none=True)
@@ -464,6 +495,15 @@ def upload_coworld(
     with CoworldUploadClient.from_login(server_url=server) as client:
         upload_manifest = _manifest_with_softmax_image_ids(client, manifest)
         response = client.upload_manifest(upload_manifest)
+        hosted_smoke_episode_ids: tuple[str, ...] = ()
+        if wait_for_hosted_smoke:
+            hosted_smoke_episode_ids = wait_for_hosted_smoke_certification(
+                client,
+                coworld_id=response.id,
+                timeout_seconds=hosted_smoke_timeout_seconds,
+                poll_seconds=hosted_smoke_poll_seconds,
+            )
+            response = client.get_coworld(response.id)
 
     return CoworldUploadResult(
         id=response.id,
@@ -472,6 +512,7 @@ def upload_coworld(
         manifest_hash=response.manifest_hash,
         size_bytes=response.size_bytes,
         canonical=response.canonical,
+        hosted_smoke_episode_ids=hosted_smoke_episode_ids,
     )
 
 
@@ -482,6 +523,9 @@ def upload_coworld_update(
     version: str | None = None,
     patch_update: str | None = None,
     image_updates: list[str] | None = None,
+    wait_for_hosted_smoke: bool = False,
+    hosted_smoke_timeout_seconds: float = 1800.0,
+    hosted_smoke_poll_seconds: float = 5.0,
 ) -> CoworldUploadResult:
     if version is None and patch_update is None and not image_updates:
         raise ValueError("--from-coworld requires --version, --patch, or --image")
@@ -494,6 +538,15 @@ def upload_coworld_update(
         _reject_mutable_registry_image_refs(manifest)
         upload_manifest = _manifest_with_softmax_image_ids(client, manifest)
         response = client.upload_manifest(upload_manifest)
+        hosted_smoke_episode_ids: tuple[str, ...] = ()
+        if wait_for_hosted_smoke:
+            hosted_smoke_episode_ids = wait_for_hosted_smoke_certification(
+                client,
+                coworld_id=response.id,
+                timeout_seconds=hosted_smoke_timeout_seconds,
+                poll_seconds=hosted_smoke_poll_seconds,
+            )
+            response = client.get_coworld(response.id)
 
     return CoworldUploadResult(
         id=response.id,
@@ -502,7 +555,63 @@ def upload_coworld_update(
         manifest_hash=response.manifest_hash,
         size_bytes=response.size_bytes,
         canonical=response.canonical,
+        hosted_smoke_episode_ids=hosted_smoke_episode_ids,
     )
+
+
+def wait_for_hosted_smoke_certification(
+    client: CoworldUploadClient,
+    *,
+    coworld_id: str,
+    timeout_seconds: float,
+    poll_seconds: float,
+) -> tuple[str, ...]:
+    deadline = time.monotonic() + timeout_seconds
+    seen: dict[str, dict[str, Any]] = {}
+
+    while True:
+        for row in client.list_episode_requests(limit=1000):
+            if row.get("coworld_id") == coworld_id:
+                episode_id = row.get("id")
+                if isinstance(episode_id, str):
+                    seen[episode_id] = row
+
+        if seen:
+            pending = [
+                row
+                for row in seen.values()
+                if str(row.get("status")) not in _HOSTED_SMOKE_TERMINAL_STATUSES
+            ]
+            failures = [
+                row
+                for row in seen.values()
+                if str(row.get("status")) in _HOSTED_SMOKE_TERMINAL_STATUSES - _HOSTED_SMOKE_SUCCESS_STATUSES
+            ]
+            if failures:
+                raise RuntimeError(_hosted_smoke_failure_message(coworld_id, failures))
+            if not pending:
+                return tuple(sorted(seen))
+
+        if time.monotonic() >= deadline:
+            if not seen:
+                raise RuntimeError(
+                    f"Timed out waiting for hosted smoke certification episodes to be created for Coworld {coworld_id}."
+                )
+            raise RuntimeError(_hosted_smoke_timeout_message(coworld_id, seen.values()))
+        time.sleep(poll_seconds)
+
+
+def _hosted_smoke_failure_message(coworld_id: str, failures: list[dict[str, Any]]) -> str:
+    details = []
+    for row in failures:
+        error = row.get("error") or row.get("error_type") or "unknown error"
+        details.append(f"{row.get('id', '<unknown>')} status={row.get('status')} error={error}")
+    return f"Hosted smoke certification failed for Coworld {coworld_id}:\n- " + "\n- ".join(details)
+
+
+def _hosted_smoke_timeout_message(coworld_id: str, rows: Any) -> str:
+    details = [f"{row.get('id', '<unknown>')} status={row.get('status')}" for row in rows]
+    return f"Timed out waiting for hosted smoke certification for Coworld {coworld_id}:\n- " + "\n- ".join(details)
 
 
 def _resolve_stored_coworld(client: CoworldUploadClient, coworld_ref: str) -> CoworldListEntry:
@@ -669,6 +778,9 @@ def upload_coworld_cmd(
     version: str | None = None,
     patch_update: str | None = None,
     image_updates: list[str] | None = None,
+    wait_for_hosted_smoke: bool = True,
+    hosted_smoke_timeout_seconds: float = 1800.0,
+    hosted_smoke_poll_seconds: float = 5.0,
 ) -> None:
     if base_coworld is not None:
         if manifest_path is not None:
@@ -679,6 +791,9 @@ def upload_coworld_cmd(
             version=version,
             patch_update=patch_update,
             image_updates=image_updates,
+            wait_for_hosted_smoke=wait_for_hosted_smoke,
+            hosted_smoke_timeout_seconds=hosted_smoke_timeout_seconds,
+            hosted_smoke_poll_seconds=hosted_smoke_poll_seconds,
         )
     else:
         if manifest_path is None:
@@ -689,7 +804,14 @@ def upload_coworld_cmd(
             manifest_path,
             server=server,
             timeout_seconds=timeout_seconds,
+            wait_for_hosted_smoke=wait_for_hosted_smoke,
+            hosted_smoke_timeout_seconds=hosted_smoke_timeout_seconds,
+            hosted_smoke_poll_seconds=hosted_smoke_poll_seconds,
         )
+    if wait_for_hosted_smoke:
+        typer.echo("Hosted smoke certification: passed")
+        if result.hosted_smoke_episode_ids:
+            typer.echo("Hosted smoke episodes: " + ", ".join(result.hosted_smoke_episode_ids))
     typer.echo(f"Upload complete: {result.name}:{result.version}")
     typer.echo(f"Coworld: {result.id}")
     typer.echo(f"Manifest hash: {result.manifest_hash}")

--- a/tests/test_coworld_upload_cli.py
+++ b/tests/test_coworld_upload_cli.py
@@ -283,6 +283,7 @@ def test_upload_coworld_command_certifies_before_uploading(
             str(manifest_path),
             "--server",
             httpserver.url_for(""),
+            "--no-wait-hosted-smoke",
         ],
     )
 
@@ -303,6 +304,109 @@ def test_upload_coworld_command_rejects_partial_options_without_base_manifest(tm
 
     assert result.exit_code != 0
     assert "--version, --patch, and --image require --from-coworld" in result.output
+
+
+def test_upload_coworld_command_waits_for_hosted_smoke_success(httpserver: HTTPServer) -> None:
+    old_coworld_id = "cow_00000000-0000-0000-0000-000000000013"
+    new_coworld_id = "cow_00000000-0000-0000-0000-000000000014"
+    image_id = "img_00000000-0000-0000-0000-000000000099"
+    manifest = _manifest_with_image(image_id)
+
+    httpserver.expect_request(
+        "/observatory/v2/coworlds",
+        method="GET",
+        query_string="limit=200&offset=0",
+    ).respond_with_json([_coworld_entry(old_coworld_id, manifest, version="0.1.0", canonical=True)])
+    httpserver.expect_request("/observatory/v2/coworlds/upload", method="POST").respond_with_json(
+        _coworld_entry(new_coworld_id, manifest, version="0.2.0", canonical=False)
+    )
+    httpserver.expect_request(
+        "/observatory/v2/episode-requests",
+        method="GET",
+        query_string="limit=1000&offset=0",
+    ).respond_with_json(
+        {
+            "entries": [
+                _episode_request("ereq_00000000-0000-0000-0000-000000000001", new_coworld_id, "completed"),
+                _episode_request("ereq_00000000-0000-0000-0000-000000000002", new_coworld_id, "completed"),
+            ]
+        }
+    )
+    httpserver.expect_request(
+        f"/observatory/v2/coworlds/{new_coworld_id}",
+        method="GET",
+    ).respond_with_json(_coworld_entry(new_coworld_id, manifest, version="0.2.0", canonical=True))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "upload-coworld",
+            "--from-coworld",
+            old_coworld_id,
+            "--version",
+            "0.2.0",
+            "--server",
+            httpserver.url_for(""),
+            "--hosted-smoke-timeout-seconds",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Hosted smoke certification: passed" in result.output
+    assert "ereq_00000000-0000-0000-0000-000000000001" in result.output
+    assert "Canonical: yes" in result.output
+
+
+def test_upload_coworld_command_fails_on_hosted_smoke_failure(httpserver: HTTPServer) -> None:
+    old_coworld_id = "cow_00000000-0000-0000-0000-000000000013"
+    new_coworld_id = "cow_00000000-0000-0000-0000-000000000014"
+    image_id = "img_00000000-0000-0000-0000-000000000099"
+    manifest = _manifest_with_image(image_id)
+
+    httpserver.expect_request(
+        "/observatory/v2/coworlds",
+        method="GET",
+        query_string="limit=200&offset=0",
+    ).respond_with_json([_coworld_entry(old_coworld_id, manifest, version="0.1.0", canonical=True)])
+    httpserver.expect_request("/observatory/v2/coworlds/upload", method="POST").respond_with_json(
+        _coworld_entry(new_coworld_id, manifest, version="0.2.0", canonical=False)
+    )
+    httpserver.expect_request(
+        "/observatory/v2/episode-requests",
+        method="GET",
+        query_string="limit=1000&offset=0",
+    ).respond_with_json(
+        {
+            "entries": [
+                _episode_request(
+                    "ereq_00000000-0000-0000-0000-000000000003",
+                    new_coworld_id,
+                    "failed",
+                    error="image pull failed",
+                )
+            ]
+        }
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "upload-coworld",
+            "--from-coworld",
+            old_coworld_id,
+            "--version",
+            "0.2.0",
+            "--server",
+            httpserver.url_for(""),
+            "--hosted-smoke-timeout-seconds",
+            "1",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Hosted smoke certification failed" in str(result.exception)
+    assert "image pull failed" in str(result.exception)
 
 
 def test_upload_coworld_from_existing_manifest_applies_patch_without_images(
@@ -363,6 +467,7 @@ def test_upload_coworld_from_existing_manifest_applies_patch_without_images(
             str(patch_path),
             "--server",
             httpserver.url_for(""),
+            "--no-wait-hosted-smoke",
         ],
     )
 
@@ -463,6 +568,7 @@ def test_upload_coworld_from_existing_manifest_updates_one_role_image(
             "commissioner.round-robin=unit-test-commissioner:latest",
             "--server",
             httpserver.url_for(""),
+            "--no-wait-hosted-smoke",
         ],
     )
 
@@ -1440,6 +1546,42 @@ def _write_manifest(tmp_path: Path, manifest: dict[str, object] | None = None) -
     manifest_path = world_dir / "coworld_manifest.json"
     manifest_path.write_text(json.dumps(_manifest() if manifest is None else manifest))
     return manifest_path
+
+
+def _coworld_entry(
+    coworld_id: str,
+    manifest: dict[str, object],
+    *,
+    version: str,
+    canonical: bool,
+) -> dict[str, object]:
+    return {
+        "id": coworld_id,
+        "name": "unit-test-game",
+        "version": version,
+        "manifest": manifest,
+        "manifest_hash": "sha256:manifest-hash",
+        "size_bytes": 1234,
+        "created_at": "2026-05-08T21:00:00Z",
+        "canonical": canonical,
+    }
+
+
+def _episode_request(
+    episode_request_id: str,
+    coworld_id: str,
+    status: str,
+    *,
+    error: str | None = None,
+) -> dict[str, object]:
+    return {
+        "id": episode_request_id,
+        "coworld_id": coworld_id,
+        "coworld_name": "unit-test-game",
+        "coworld_version": "0.2.0",
+        "status": status,
+        "error": error,
+    }
 
 
 def _manifest() -> dict[str, object]:


### PR DESCRIPTION
## Summary
- make `coworld upload-coworld` wait for hosted smoke certification by default
- fail the upload command immediately when hosted smoke episodes fail or never appear
- refresh the uploaded Coworld before printing the final canonical status
- add `--no-wait-hosted-smoke` for explicit opt-out and `--hosted-smoke-timeout-seconds` for timeout control

## Validation
- `uv run --extra test pytest tests/test_coworld_upload_cli.py -q` -> 35 passed
- `uv run --extra test ruff check --config /home/kyleherndon/metta/.ruff.toml src/coworld/upload.py src/coworld/cli.py tests/test_coworld_upload_cli.py` -> passed

Note: plain `uv run --extra test ruff check .` is not runnable from this standalone worktree because `pyproject.toml` extends `../../.ruff.toml`; I ran ruff with the monorepo config path explicitly.
