### PR TITLE
Fix next-version after non-canonical Coworld uploads

### DIFF
--- a/src/coworld/cli.py
+++ b/src/coworld/cli.py
@@ -507,11 +507,14 @@ def next_version(
     server: Annotated[str, typer.Option("--server", help="Observatory API server URL.")] = DEFAULT_SUBMIT_SERVER,
 ) -> None:
     with CoworldUploadClient.from_login(server_url=server) as client:
-        coworld = client.find_canonical_coworld(coworld_name)
-    if coworld is None:
-        console.print(f"[red]Canonical Coworld not found: {coworld_name}. Pass an explicit version instead.[/red]")
+        latest_version = max(
+            (Version(coworld.version) for coworld in client.iter_coworlds_by_name(coworld_name)),
+            default=None,
+        )
+    if latest_version is None:
+        console.print(f"[red]Coworld not found: {coworld_name}. Pass an explicit version instead.[/red]")
         raise typer.Exit(1)
-    release = Version(coworld.version).release
+    release = latest_version.release
     typer.echo(".".join(str(part) for part in (*release[:-1], release[-1] + 1)))
 
 

--- a/src/coworld/upload.py
+++ b/src/coworld/upload.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Iterator, Self
 from urllib.parse import quote
 from uuid import UUID
 
@@ -517,16 +517,22 @@ class CoworldUploadClient:
         return CoworldCertificationStatus.model_validate(response.json())
 
     def find_canonical_coworld(self, name: str) -> CoworldListEntry | None:
+        for coworld in self.iter_coworlds_by_name(name):
+            if coworld.canonical:
+                return coworld
+        return None
+
+    def iter_coworlds_by_name(self, name: str) -> Iterator[CoworldListEntry]:
         target_name = _coworld_name_key(name)
         limit = 200
         offset = 0
         while True:
             coworlds = self.list_coworlds(limit=limit, offset=offset)
             for coworld in coworlds:
-                if _coworld_name_key(coworld.name) == target_name and coworld.canonical:
-                    return coworld
+                if _coworld_name_key(coworld.name) == target_name:
+                    yield coworld
             if len(coworlds) < limit:
-                return None
+                return
             offset += limit
 
     def lookup_policy_version(self, *, name: str, version: int | None = None) -> PolicyVersionRow | None:

--- a/tests/test_coworld_upload_cli.py
+++ b/tests/test_coworld_upload_cli.py
@@ -126,7 +126,38 @@ def test_next_version_command_bumps_canonical_patch(httpserver: HTTPServer) -> N
     assert result.output == "0.1.23\n"
 
 
-def test_next_version_command_fails_without_canonical_coworld(httpserver: HTTPServer) -> None:
+def test_next_version_command_bumps_past_noncanonical_versions(httpserver: HTTPServer) -> None:
+    manifest = _manifest()
+    httpserver.expect_request(
+        "/observatory/v2/coworlds",
+        method="GET",
+        query_string="limit=200&offset=0",
+    ).respond_with_json(
+        [
+            _coworld_entry(
+                "cow_00000000-0000-0000-0000-000000000011",
+                manifest,
+                name="crewrift_prime",
+                version="0.4.66",
+                canonical=False,
+            ),
+            _coworld_entry(
+                "cow_00000000-0000-0000-0000-000000000010",
+                manifest,
+                name="crewrift_prime",
+                version="0.4.65",
+                canonical=True,
+            ),
+        ]
+    )
+
+    result = CliRunner().invoke(app, ["next-version", "crewrift-prime", "--server", httpserver.url_for("")])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "0.4.67\n"
+
+
+def test_next_version_command_fails_without_existing_coworld(httpserver: HTTPServer) -> None:
     httpserver.expect_request(
         "/observatory/v2/coworlds",
         method="GET",
@@ -136,7 +167,7 @@ def test_next_version_command_fails_without_canonical_coworld(httpserver: HTTPSe
     result = CliRunner().invoke(app, ["next-version", "crewrift", "--server", httpserver.url_for("")], color=False)
 
     assert result.exit_code == 1
-    assert "Canonical Coworld not found: crewrift" in result.output
+    assert "Coworld not found: crewrift" in result.output
 
 
 def test_upload_coworld_rejects_mutable_registry_image_refs(


### PR DESCRIPTION
## Summary
- make coworld next-version allocate from every uploaded version for a Coworld name, not only the canonical row
- keep canonical lookup behavior for commands that need the active Coworld
- add coverage for the Crewrift registry shape where non-canonical 0.4.66 exists above canonical 0.4.65

## Proof
- env -u UV_PROJECT -u UV_PROJECT_ENVIRONMENT -u VIRTUAL_ENV uv run --project . --extra test pytest tests/test_coworld_upload_cli.py -k next_version -q
- env -u UV_PROJECT -u UV_PROJECT_ENVIRONMENT -u VIRTUAL_ENV uv run --project . --extra test ruff check --config /Users/relh/Code/metta/.ruff.toml src/coworld/cli.py src/coworld/upload.py tests/test_coworld_upload_cli.py
- git diff --check
- env -u UV_PROJECT -u UV_PROJECT_ENVIRONMENT -u VIRTUAL_ENV uv run --project . coworld next-version crewrift_prime -> 0.4.67

Note: the repo-local ruff invocation currently fails before linting because pyproject.toml extends ../../.ruff.toml, which resolves to /Users/relh/.ruff.toml in this standalone checkout. I used the matching Metta ruff config explicitly for this PR's scoped lint.